### PR TITLE
chore(ci): make the pipelines build on github runners & 2 times faster

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,6 @@ jobs:
         run: cargo test
   online:
     runs-on: ubuntu-latest
-    needs: offline
     steps:
       - name: Check debug compilation
         run: cargo build --features network

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,17 +2,17 @@ name: Check
 on: [push, pull_request]
 jobs:
   format:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: cargo fmt --check
   doc:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: cargo doc --all-features --no-deps
   offline:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Check debug compilation
@@ -24,7 +24,7 @@ jobs:
       - name: Unit tests
         run: cargo test
   online:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     needs: offline
     steps:
       - name: Check debug compilation

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,33 +4,31 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: cargo fmt --check
-  doc:
+  build-debug:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run: cargo doc --all-features --no-deps
-  offline:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check debug compilation
+      - uses: actions/checkout@v6
+      - name: Build (offline-mode)
         run: cargo build
-      - name: Check release compilation
-        run: cargo build --release
-      - name: Clippy
+      - name: Build (online-mode)
+        run: cargo build --features network
+      - name: Clippy (offline-mode)
         run: cargo clippy --all-targets -- -D warnings
-      - name: Unit tests
+      - name: Clippy (online-mode)
+        run: cargo clippy --features network --all-targets -- -D warnings
+      - name: Unit tests (offline-mode)
         run: cargo test
-  online:
+      - name: Unit tests (online-mode)
+        run: cargo test --features network --all-targets
+  build-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Check debug compilation
-        run: cargo build --features network
-      - name: Check release compilation
+      - uses: actions/checkout@v6
+      - name: Build (offline-mode)
+        run: cargo build --release
+      - name: Build (online-mode)
         run: cargo build --release --features network
-      - name: Clippy
-        run: cargo clippy --features network --all-targets -- -D warnings
-      - name: Unit tests
-        run: cargo test --features network --all-targets
+      - name: Build documentation
+        run: cargo doc --all-features --no-deps


### PR DESCRIPTION
Rewrite pipelines to:
- run on GitHub runners
- parallelize build by type (debug, release) to leverage rust compilation cache (making it 2x faster)

Note: No github cache has been setup for now, I will look into it to make it even faster