### PR TITLE
refactor: clean blimp::install function, fix a bug

### DIFF
--- a/client/src/install.rs
+++ b/client/src/install.rs
@@ -56,7 +56,7 @@ fn packages_to_install<'r>(
 	// TODO list all packages for all repo, instead of
 	// reading index for each repo for each package
 	for name in names {
-		let pkg = repository::get_package_with_constraint(&repos, env.arch(), name, None)?;
+		let pkg = repository::get_package_with_constraint(repos, env.arch(), name, None)?;
 		let Some((repo, pkg)) = pkg else {
 			eprintln!("Package `{name}` not found!");
 			failed = true;
@@ -90,13 +90,13 @@ fn packages_with_deps_to_install<'r>(
 	let mut total_packages = packages.clone();
 	// TODO check dependencies for all packages at once to avoid duplicate errors
 	// Resolving dependencies
-	for (package, _) in packages {
+	for package in packages.keys() {
 		let res = package.resolve_dependencies(
 			&mut total_packages,
 			&mut |name, version_constraint| {
 				// TODO yet another call for reading whole repo index
 				let res = repository::get_package_with_constraint(
-					&repos,
+					repos,
 					env.arch(),
 					name,
 					Some(version_constraint),
@@ -231,7 +231,7 @@ fn install_packages<'r>(
 	for (pkg, repo) in total_packages {
 		println!("Installing `{}`...", pkg.name);
 		let archive_path = repo.get_archive_path(env.arch(), &pkg.name, &pkg.version);
-		if let Err(e) = env.install(&pkg, &archive_path) {
+		if let Err(e) = env.install(pkg, &archive_path) {
 			eprintln!("Failed to install `{}`: {e}", &pkg.name);
 			failed = true;
 		}
@@ -252,16 +252,16 @@ pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
 		bail!("must specify at least one package");
 	}
 	let repos = env.list_repositories()?;
-	let packages = packages_to_install(names, &repos, &env)?;
+	let packages = packages_to_install(names, &repos, env)?;
 
 	println!("Resolving dependencies...");
-	let total_packages = packages_with_deps_to_install(&packages, &repos, &env)?;
+	let total_packages = packages_with_deps_to_install(&packages, &repos, env)?;
 	let mut total_packages: Vec<_> = total_packages.into_iter().collect();
 	total_packages.sort_unstable_by(|(p0, _), (p1, _)| p0.name.cmp(&p1.name));
 
 	println!("Packages to be installed:");
 	#[cfg(feature = "network")]
-	print_download_size(&total_packages, &env).await?;
+	print_download_size(&total_packages, env).await?;
 	#[cfg(not(feature = "network"))]
 	{
 		for pkg in total_packages.keys() {
@@ -275,9 +275,9 @@ pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
 	#[cfg(feature = "network")]
 	{
 		println!("Downloading packages...");
-		download_packages(&total_packages, &env).await?;
+		download_packages(&total_packages, env).await?;
 	}
 	println!();
 	println!("Installing packages...");
-	install_packages(&total_packages, &env)
+	install_packages(&total_packages, env)
 }

--- a/client/src/install.rs
+++ b/client/src/install.rs
@@ -218,7 +218,30 @@ async fn download_packages<'r>(
 	Ok(())
 }
 
-// TODO Clean
+/// Install all packages into environment.
+///
+/// Arguments:
+/// - `total_packages` is the whole list of packages to install
+/// - `env` is the environment to install on
+fn install_packages<'r>(
+	total_packages: &PackagesWithRepositoryVec<'r>,
+	env: &Environment,
+) -> Result<()> {
+	let mut failed = false;
+	for (pkg, repo) in total_packages {
+		println!("Installing `{}`...", pkg.name);
+		let archive_path = repo.get_archive_path(env.arch(), &pkg.name, &pkg.version);
+		if let Err(e) = env.install(&pkg, &archive_path) {
+			eprintln!("Failed to install `{}`: {e}", &pkg.name);
+			failed = true;
+		}
+	}
+	if failed {
+		bail!("installation failed");
+	}
+	Ok(())
+}
+
 /// Installs the given list of packages.
 ///
 /// Arguments:
@@ -256,18 +279,5 @@ pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
 	}
 	println!();
 	println!("Installing packages...");
-	// Install all packages
-	let mut failed = false;
-	for (pkg, repo) in total_packages {
-		println!("Installing `{}`...", pkg.name);
-		let archive_path = repo.get_archive_path(env.arch(), &pkg.name, &pkg.version);
-		if let Err(e) = env.install(&pkg, &archive_path) {
-			eprintln!("Failed to install `{}`: {e}", &pkg.name);
-			failed = true;
-		}
-	}
-	if failed {
-		bail!("installation failed");
-	}
-	Ok(())
+	install_packages(&total_packages, &env)
 }

--- a/client/src/install.rs
+++ b/client/src/install.rs
@@ -24,7 +24,7 @@ use common::{
 	maestro_utils::util::ByteSize,
 	package::Package,
 	repository,
-	repository::{remote::Remote, Repository},
+	repository::Repository,
 	Environment,
 };
 use std::{collections::HashMap, fs};
@@ -39,23 +39,13 @@ pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
 	if names.is_empty() {
 		bail!("must specify at least one package");
 	}
-	// The list of repositories
-	let repos = env
-		.local_repos()
-		.iter()
-		.cloned()
-		.map(Repository::local)
-		// Add remote repositories
-		.chain(
-			Remote::load_list(env)?
-				.iter()
-				.map(|r| r.load_repository(env).unwrap()),
-		) // TODO handle error
-		.collect::<Vec<_>>();
+	let repos = env.list_repositories()?;
 	// Tells whether the operation failed
 	let mut failed = false;
 	// The list of packages to install with their respective repository
 	let mut packages = HashMap::<Package, &Repository>::new();
+	// TODO list all packages for all repo, instead of
+	// reading index for each repo for each package
 	for name in names {
 		let pkg = repository::get_package_with_constraint(&repos, env.arch(), name, None)?;
 		let Some((repo, pkg)) = pkg else {

--- a/client/src/install.rs
+++ b/client/src/install.rs
@@ -125,6 +125,38 @@ fn packages_with_deps_to_install<'r>(
 	Ok(total_packages)
 }
 
+/// Print download size for each dependency
+/// and the total download size.
+///
+/// Arguments:
+/// - `total_packages` is the whole list of packages to install
+/// - `env` is the environment to install on
+#[cfg(feature = "network")]
+async fn print_download_size<'r>(
+	total_packages: &Vec<(Package, &'r Repository)>,
+	env: &Environment,
+) -> Result<()> {
+	let mut total_size = 0;
+	for (pkg, repo) in total_packages {
+		let name = &pkg.name;
+		let version = &pkg.version;
+		match repo.get_package(env.arch(), name, version)? {
+			Some(_) => println!("\t- {name} {version} - cached"),
+			None => {
+				// Get package size from remote
+				let remote = repo.get_remote().unwrap();
+				let size = remote.get_size(env, pkg).await?;
+				total_size += size;
+				println!("\t- {name} {version} (download size: {})", ByteSize(size));
+			}
+		}
+	}
+	println!();
+	println!("Total download size: {}", ByteSize(total_size));
+	println!();
+	Ok(())
+}
+
 // TODO Clean
 /// Installs the given list of packages.
 ///
@@ -145,26 +177,7 @@ pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
 
 	println!("Packages to be installed:");
 	#[cfg(feature = "network")]
-	{
-		let mut total_size = 0;
-		for (pkg, repo) in &total_packages {
-			let name = &pkg.name;
-			let version = &pkg.version;
-			match repo.get_package(env.arch(), name, version)? {
-				Some(_) => println!("\t- {name} {version} - cached"),
-				None => {
-					// Get package size from remote
-					let remote = repo.get_remote().unwrap();
-					let size = remote.get_size(env, pkg).await?;
-					total_size += size;
-					println!("\t- {name} {version} (download size: {})", ByteSize(size));
-				}
-			}
-		}
-		println!();
-		println!("Total download size: {}", ByteSize(total_size));
-		println!();
-	}
+	print_download_size(&total_packages, &env).await?;
 	#[cfg(not(feature = "network"))]
 	{
 		for pkg in total_packages.keys() {
@@ -175,6 +188,7 @@ pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
 		println!("Aborting.");
 		return Ok(());
 	}
+	let mut failed = false;
 	#[cfg(feature = "network")]
 	{
 		println!("Downloading packages...");

--- a/client/src/install.rs
+++ b/client/src/install.rs
@@ -29,8 +29,11 @@ use common::{
 };
 use std::{collections::HashMap, fs};
 
+/// Map of packages with their respective repository
+type PackagesWithRepositoryMap<'r> = HashMap<Package, &'r Repository>;
+
 /// List of packages with their respective repository
-type PackagesWithRepository<'r> = HashMap<Package, &'r Repository>;
+type PackagesWithRepositoryVec<'r> = Vec<(Package, &'r Repository)>;
 
 /// Get the list of packages to install.
 ///
@@ -46,7 +49,7 @@ fn packages_to_install<'r>(
 	names: &[String],
 	repos: &'r [Repository],
 	env: &Environment,
-) -> Result<PackagesWithRepository<'r>> {
+) -> Result<PackagesWithRepositoryMap<'r>> {
 	let mut failed = false;
 	let mut packages = HashMap::<Package, &Repository>::new();
 
@@ -78,10 +81,10 @@ fn packages_to_install<'r>(
 /// - `repos` is repositories to search packages into
 /// - `env` is the environment to install on
 fn packages_with_deps_to_install<'r>(
-	packages: &PackagesWithRepository<'r>,
+	packages: &PackagesWithRepositoryMap<'r>,
 	repos: &'r [Repository],
 	env: &Environment,
-) -> Result<PackagesWithRepository<'r>> {
+) -> Result<PackagesWithRepositoryMap<'r>> {
 	let mut failed = false;
 	// The list of all packages, dependencies included
 	let mut total_packages = packages.clone();
@@ -133,7 +136,7 @@ fn packages_with_deps_to_install<'r>(
 /// - `env` is the environment to install on
 #[cfg(feature = "network")]
 async fn print_download_size<'r>(
-	total_packages: &Vec<(Package, &'r Repository)>,
+	total_packages: &PackagesWithRepositoryVec<'r>,
 	env: &Environment,
 ) -> Result<()> {
 	let mut total_size = 0;
@@ -154,6 +157,64 @@ async fn print_download_size<'r>(
 	println!();
 	println!("Total download size: {}", ByteSize(total_size));
 	println!();
+	Ok(())
+}
+
+/// Download packages and print in case of cache or failure.
+///
+/// Arguments:
+/// - `total_packages` is the whole list of packages to install
+/// - `env` is the environment to install on
+#[cfg(feature = "network")]
+async fn download_packages<'r>(
+	total_packages: &PackagesWithRepositoryVec<'r>,
+	env: &Environment,
+) -> Result<()> {
+	let mut failed = false;
+	let mut futures = Vec::new();
+	// TODO download biggest packages first (sort_unstable by decreasing size)
+	for (pkg, repo) in total_packages {
+		if repo.is_in_cache(env.arch(), &pkg.name, &pkg.version) {
+			println!("`{}` is in cache.", &pkg.name);
+			continue;
+		}
+		if let Some(remote) = repo.get_remote() {
+			// TODO limit the number of packages downloaded concurrently
+			futures.push((
+				&pkg.name,
+				&pkg.version,
+				// TODO spawn task
+				async {
+					use common::download::DownloadTask;
+					use std::fs::File;
+
+					let path = repo.get_archive_path(env.arch(), &pkg.name, &pkg.version);
+					// Ensure the parent directory exists
+					if let Some(parent) = path.parent() {
+						fs::create_dir_all(parent)?;
+					}
+					// Download
+					let file = File::create(path)?;
+					let url = remote.download_url(env, pkg);
+					let mut task = DownloadTask::new(&url, &file).await?;
+					while task.next().await? > 0 {}
+					Ok::<(), common::anyhow::Error>(())
+				},
+			));
+		}
+	}
+	for (name, version, f) in futures {
+		match f.await {
+			Ok(()) => continue,
+			Err(error) => {
+				eprintln!("Failed to download `{name}` version `{version}`: {error}");
+				failed = true;
+			}
+		}
+	}
+	if failed {
+		bail!("installation failed");
+	}
 	Ok(())
 }
 
@@ -188,57 +249,15 @@ pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
 		println!("Aborting.");
 		return Ok(());
 	}
-	let mut failed = false;
 	#[cfg(feature = "network")]
 	{
 		println!("Downloading packages...");
-		let mut futures = Vec::new();
-		// TODO download biggest packages first (sort_unstable by decreasing size)
-		for (pkg, repo) in &total_packages {
-			if repo.is_in_cache(env.arch(), &pkg.name, &pkg.version) {
-				println!("`{}` is in cache.", &pkg.name);
-				continue;
-			}
-			if let Some(remote) = repo.get_remote() {
-				// TODO limit the number of packages downloaded concurrently
-				futures.push((
-					&pkg.name,
-					&pkg.version,
-					// TODO spawn task
-					async {
-						use common::download::DownloadTask;
-						use std::fs::File;
-
-						let path = repo.get_archive_path(env.arch(), &pkg.name, &pkg.version);
-						// Ensure the parent directory exists
-						if let Some(parent) = path.parent() {
-							fs::create_dir_all(parent)?;
-						}
-						// Download
-						let file = File::create(path)?;
-						let url = remote.download_url(env, pkg);
-						let mut task = DownloadTask::new(&url, &file).await?;
-						while task.next().await? > 0 {}
-						Ok::<(), common::anyhow::Error>(())
-					},
-				));
-			}
-		}
-		for (name, version, f) in futures {
-			match f.await {
-				Ok(()) => continue,
-				Err(error) => {
-					eprintln!("Failed to download `{name}` version `{version}`: {error}");
-				}
-			}
-		}
-		if failed {
-			bail!("installation failed");
-		}
+		download_packages(&total_packages, &env).await?;
 	}
 	println!();
 	println!("Installing packages...");
 	// Install all packages
+	let mut failed = false;
 	for (pkg, repo) in total_packages {
 		println!("Installing `{}`...", pkg.name);
 		let archive_path = repo.get_archive_path(env.arch(), &pkg.name, &pkg.version);

--- a/client/src/install.rs
+++ b/client/src/install.rs
@@ -29,8 +29,10 @@ use common::{
 };
 use std::{collections::HashMap, fs};
 
-/// Get the list of packages to install with their
-/// respective repository, from package names & repositories.
+/// List of packages with their respective repository
+type PackagesWithRepository<'r> = HashMap<Package, &'r Repository>;
+
+/// Get the list of packages to install.
 ///
 /// Print if package is missing or already installed.
 ///
@@ -44,7 +46,7 @@ fn packages_to_install<'r>(
 	names: &[String],
 	repos: &'r [Repository],
 	env: &Environment,
-) -> Result<HashMap<Package, &'r Repository>> {
+) -> Result<PackagesWithRepository<'r>> {
 	let mut failed = false;
 	let mut packages = HashMap::<Package, &Repository>::new();
 
@@ -69,19 +71,17 @@ fn packages_to_install<'r>(
 	Ok(packages)
 }
 
-// TODO Clean
-/// Installs the given list of packages.
+/// Get packages to install with their dependencies.
 ///
 /// Arguments:
-/// - `names` is the list of packages to install.
-/// - `env` is the blimp environment.
-pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
-	if names.is_empty() {
-		bail!("must specify at least one package");
-	}
-	let repos = env.list_repositories()?;
-	let packages = packages_to_install(names, &repos, &env)?;
-	println!("Resolving dependencies...");
+/// - `packages` is package list to install
+/// - `repos` is repositories to search packages into
+/// - `env` is the environment to install on
+fn packages_with_deps_to_install<'r>(
+	packages: &PackagesWithRepository<'r>,
+	repos: &'r [Repository],
+	env: &Environment,
+) -> Result<PackagesWithRepository<'r>> {
 	let mut failed = false;
 	// The list of all packages, dependencies included
 	let mut total_packages = packages.clone();
@@ -91,6 +91,7 @@ pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
 		let res = package.resolve_dependencies(
 			&mut total_packages,
 			&mut |name, version_constraint| {
+				// TODO yet another call for reading whole repo index
 				let res = repository::get_package_with_constraint(
 					&repos,
 					env.arch(),
@@ -121,9 +122,27 @@ pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
 	if failed {
 		bail!("installation failed");
 	}
-	// List packages to be installed
+	Ok(total_packages)
+}
+
+// TODO Clean
+/// Installs the given list of packages.
+///
+/// Arguments:
+/// - `names` is the list of packages to install.
+/// - `env` is the blimp environment.
+pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
+	if names.is_empty() {
+		bail!("must specify at least one package");
+	}
+	let repos = env.list_repositories()?;
+	let packages = packages_to_install(names, &repos, &env)?;
+
+	println!("Resolving dependencies...");
+	let total_packages = packages_with_deps_to_install(&packages, &repos, &env)?;
 	let mut total_packages: Vec<_> = total_packages.into_iter().collect();
 	total_packages.sort_unstable_by(|(p0, _), (p1, _)| p0.name.cmp(&p1.name));
+
 	println!("Packages to be installed:");
 	#[cfg(feature = "network")]
 	{

--- a/client/src/install.rs
+++ b/client/src/install.rs
@@ -29,21 +29,25 @@ use common::{
 };
 use std::{collections::HashMap, fs};
 
-// TODO Clean
-/// Installs the given list of packages.
+/// Get the list of packages to install with their
+/// respective repository, from package names & repositories.
+///
+/// Print if package is missing or already installed.
+///
+/// If at least one package is missing, error out.
 ///
 /// Arguments:
-/// - `names` is the list of packages to install.
-/// - `env` is the blimp environment.
-pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
-	if names.is_empty() {
-		bail!("must specify at least one package");
-	}
-	let repos = env.list_repositories()?;
-	// Tells whether the operation failed
+/// - `names` is packages names to search
+/// - `repos` is repositories to search packages into
+/// - `env` is the environment to install on
+fn packages_to_install<'r>(
+	names: &[String],
+	repos: &'r [Repository],
+	env: &Environment,
+) -> Result<HashMap<Package, &'r Repository>> {
 	let mut failed = false;
-	// The list of packages to install with their respective repository
 	let mut packages = HashMap::<Package, &Repository>::new();
+
 	// TODO list all packages for all repo, instead of
 	// reading index for each repo for each package
 	for name in names {
@@ -62,7 +66,23 @@ pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
 	if failed {
 		bail!("installation failed");
 	}
+	Ok(packages)
+}
+
+// TODO Clean
+/// Installs the given list of packages.
+///
+/// Arguments:
+/// - `names` is the list of packages to install.
+/// - `env` is the blimp environment.
+pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
+	if names.is_empty() {
+		bail!("must specify at least one package");
+	}
+	let repos = env.list_repositories()?;
+	let packages = packages_to_install(names, &repos, &env)?;
 	println!("Resolving dependencies...");
+	let mut failed = false;
 	// The list of all packages, dependencies included
 	let mut total_packages = packages.clone();
 	// TODO check dependencies for all packages at once to avoid duplicate errors

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -33,7 +33,11 @@ pub mod repository;
 pub mod util;
 pub mod version;
 
-use crate::{util::current_arch, version::Version};
+use crate::{
+	repository::{remote::Remote, Repository},
+	util::current_arch,
+	version::Version,
+};
 use anyhow::Result;
 use package::{InstalledPackage, Package};
 use std::{
@@ -96,10 +100,12 @@ impl Environment {
 	}
 
 	/// Returns the sysroot of the current environment.
+	#[inline]
 	pub fn sysroot(&self) -> &Path {
 		&self.sysroot
 	}
 
+	// TODO check if used in an other repo
 	/// Returns the local repositories list
 	#[inline]
 	pub fn local_repos(&self) -> &[PathBuf] {
@@ -110,6 +116,23 @@ impl Environment {
 	#[inline]
 	pub fn arch(&self) -> &str {
 		&self.arch
+	}
+
+	/// List local & remote repositories
+	pub fn list_repositories(&self) -> Result<Vec<Repository>> {
+		let repos = self
+			.local_repos()
+			.iter()
+			.cloned()
+			.map(Repository::local)
+			// Add remote repositories
+			.chain(
+				Remote::load_list(self)?
+					.iter()
+					.map(|r| r.load_repository(self).unwrap()),
+			) // TODO handle error
+			.collect::<Vec<_>>();
+		Ok(repos)
 	}
 
 	/// If installed, returns the version of the package with the given `name`


### PR DESCRIPTION
Make the blimp::install function fit entirely on screen by extracting a lot of functions.

Also fixes a bug where a package download error was not stopping the installation process.