### PR TITLE
feat: add macOS support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,10 @@ jobs:
   build-debug:
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     name: Build Debug & Checks
     steps:
       - uses: actions/checkout@v6
@@ -53,7 +56,10 @@ jobs:
   build-release:
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     name: Build Release
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
 
 Blimp is a simple package manager for Unix-like operating systems, more specifically for [Maestro](https://github.com/maestro-os/maestro).
 
+> [!IMPORTANT]
+> Blimp is currently in early development, and is not yet ready for production use. Expect breaking changes and instability.
+
+> [!CAUTION]
+> macOS is currently supported for development purposes only. Use with caution as your system integrity is not guaranteed.
+
 This repository contains the following components:
 - `blimp`: The package manager itself
 - `blimp-builder`: An utility to build packages
@@ -81,7 +87,8 @@ The command builds the package according to the descriptor, then installs it in 
 
 The `--package` flag can be used to write the resulting package into an archive instead of installing it. In which case, the output directory is considered as a repository instead of a system root.
 
-> **Note**: the structure of package descriptors and output packages are not yet documented as they are unstable
+> [!NOTE]
+> The structure of package descriptors and output packages are not yet documented as they are unstable.
 
 ### Bootstrapping
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 
 [![AGPL-3.0 license](https://img.shields.io/badge/license-AGPL--3.0-blue.svg?style=for-the-badge&logo=book)](./COPYING)
 ![Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmaestro-os%2Fblimp%2Fmaster%2Fclient%2FCargo.toml&query=%24.package.version&style=for-the-badge&label=version)
-![Continuous integration](https://img.shields.io/github/actions/workflow/status/maestro-os/blimp/check.yml?style=for-the-badge&logo=github)
+![Continuous integration](https://img.shields.io/github/actions/workflow/status/maestro-os/blimp/build.yml?style=for-the-badge&logo=github)
+![Discord](https://img.shields.io/discord/971452040821760080?style=for-the-badge&link=https%3A%2F%2Fdiscord.gg%2F4JMBN3YPAk)
 
 # About
 

--- a/builder/src/build.rs
+++ b/builder/src/build.rs
@@ -45,16 +45,6 @@ use std::{
 	sync::Arc,
 };
 
-#[cfg(target_os = "linux")]
-fn makedev(major: u32, minor: u32) -> libc::dev_t {
-	libc::makedev(major, minor)
-}
-
-#[cfg(target_os = "macos")]
-fn makedev(major: u32, minor: u32) -> libc::dev_t {
-	libc::makedev(major as i32, minor as i32)
-}
-
 /// Get original build-hook file path
 fn get_build_hook_path(input_path: &Path) -> io::Result<PathBuf> {
 	let absolute_input = fs::canonicalize(input_path)?;
@@ -83,7 +73,7 @@ fn create_dev_nodes(sysroot: &Path) -> io::Result<()> {
 		let cpath = CString::new(path.as_os_str().as_bytes())
 			.map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
 		let mode = libc::S_IFCHR | 0o666;
-		let dev = makedev(*major, *minor);
+		let dev = libc::makedev(*major as _, *minor as _);
 		let rc = unsafe { libc::mknod(cpath.as_ptr(), mode, dev) };
 		if rc != 0 {
 			return Err(io::Error::last_os_error());

--- a/builder/src/build.rs
+++ b/builder/src/build.rs
@@ -45,6 +45,16 @@ use std::{
 	sync::Arc,
 };
 
+#[cfg(target_os = "linux")]
+fn makedev(major: u32, minor: u32) -> libc::dev_t {
+	libc::makedev(major, minor)
+}
+
+#[cfg(target_os = "macos")]
+fn makedev(major: u32, minor: u32) -> libc::dev_t {
+	libc::makedev(major as i32, minor as i32)
+}
+
 /// Get original build-hook file path
 fn get_build_hook_path(input_path: &Path) -> io::Result<PathBuf> {
 	let absolute_input = fs::canonicalize(input_path)?;
@@ -73,7 +83,7 @@ fn create_dev_nodes(sysroot: &Path) -> io::Result<()> {
 		let cpath = CString::new(path.as_os_str().as_bytes())
 			.map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
 		let mode = libc::S_IFCHR | 0o666;
-		let dev = libc::makedev(*major, *minor);
+		let dev = makedev(*major, *minor);
 		let rc = unsafe { libc::mknod(cpath.as_ptr(), mode, dev) };
 		if rc != 0 {
 			return Err(io::Error::last_os_error());


### PR DESCRIPTION
Add support for compiling blimp on macOS.

⚠️ Warning: At this point, there is no guarantee blimp will not kill your system.