### PR TITLE
fix: offline-mode build + ci: make it faster (better job splitting, caching & conditional job eviction) & improve jobs naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,19 +33,19 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Clippy (offline-mode)
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --no-default-features --all-targets -- -D warnings
 
       - name: Clippy (online-mode)
         run: cargo clippy --features network --all-targets -- -D warnings
 
       - name: Build (offline-mode)
-        run: cargo build --locked
+        run: cargo build --locked --no-default-features --all-targets
 
       - name: Build (online-mode)
-        run: cargo build --locked --features network
+        run: cargo build --locked --features network --all-targets
 
       - name: Unit tests (offline-mode)
-        run: cargo test
+        run: cargo test --no-default-features --all-targets
 
       - name: Unit tests (online-mode)
         run: cargo test --features network --all-targets
@@ -66,10 +66,10 @@ jobs:
           key: cargo-target-release-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build (offline-mode)
-        run: cargo build --locked --release
+        run: cargo build --locked --release --no-default-features --all-targets
 
       - name: Build (online-mode)
-        run: cargo build --locked --release --features network
+        run: cargo build --locked --release --features network --all-targets
 
   build-doc:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,19 +20,14 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-
+          key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - &cache-debug
         name: Cache target/debug
         uses: actions/cache@v5
         with:
           path: target/debug
-          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-debug
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-
-            ${{ runner.os }}-
+          key: cargo-target-debug-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check formatting
         run: cargo fmt -- --check
@@ -68,10 +63,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: target/release
-          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-release
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-
-            ${{ runner.os }}-
+          key: cargo-target-release-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build (offline-mode)
         run: cargo build --locked --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,68 +1,15 @@
-name: Check
+name: Build
 on:
   push:
     branches: [master]
   pull_request:
 
 jobs:
-  sonarcloud:
-    permissions:
-      pull-requests: read # to decorate PRs with analysis results
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # required for SonarCloud blame and PR decoration
-
-      - name: Cache cargo-llvm-cov binary
-        id: cache-llvm-cov
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cargo-llvm-cov
-          key: ${{ runner.os }}-cargo-llvm-cov-0.8.5
-
-      - name: Cache target/llvm-cov-target
-        id: cache-llvm-cov-target
-        uses: actions/cache@v5
-        with:
-          path: target/llvm-cov-target
-          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-llvm-cov
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-
-            ${{ runner.os }}-
-
-      - name: Install cargo-llvm-cov
-        if: steps.cache-llvm-cov.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@b651345a718c8f44efa2460560b3dbf29cbd7ee1 # v2.75.26
-        with:
-          tool: cargo-llvm-cov@0.8.5
-
-      - name: Generate code coverage
-        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
-
-      - name: Fix LCOV paths for SonarCloud container
-        run: sed -i "s|$(pwd)|/github/workspace|g" lcov.info
-
-      - name: Generate Clippy report
-        run: cargo clippy --workspace --all-features --message-format=json 2>/dev/null > clippy-report.json || true
-
-      - name: Analyze with SonarCloud
-        uses: SonarSource/sonarcloud-github-action@4006f663ecaf1f8093e8e4abb9227f6041f52216 # v2.2.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >-
-            -Dsonar.projectKey=maestro-os_blimp
-            -Dsonar.organization=maestro-os
-            -Dsonar.rust.lcov.reportPaths=lcov.info
-            -Dsonar.rust.clippy.reportPaths=clippy-report.json
-
   build-debug:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    name: build-debug & checks
+    name: Build Debug & Checks
     steps:
       - uses: actions/checkout@v6
 
@@ -112,9 +59,9 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    name: Build Release
     steps:
       - uses: actions/checkout@v6
-
       - *cache-registry
 
       - name: Cache target/release
@@ -136,9 +83,9 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    name: Build Documentation
     steps:
       - uses: actions/checkout@v6
       - *cache-registry
       - *cache-debug
-      - name: Build documentation
-        run: cargo doc --all-features --no-deps
+      - run: cargo doc --all-features --no-deps

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,6 +22,16 @@ jobs:
           path: ~/.cargo/bin/cargo-llvm-cov
           key: ${{ runner.os }}-cargo-llvm-cov-0.8.5
 
+      - name: Cache target/llvm-cov-target
+        id: cache-llvm-cov-target
+        uses: actions/cache@v5
+        with:
+          path: target/llvm-cov-target
+          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-llvm-cov
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-
+            ${{ runner.os }}-
+
       - name: Install cargo-llvm-cov
         if: steps.cache-llvm-cov.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@b651345a718c8f44efa2460560b3dbf29cbd7ee1 # v2.75.26

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,15 +5,6 @@ on:
   pull_request:
 
 jobs:
-  format:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Check formatting
-        run: cargo fmt -- --check
-
   sonarcloud:
     permissions:
       pull-requests: read # to decorate PRs with analysis results
@@ -61,6 +52,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    name: build-debug & checks
     steps:
       - uses: actions/checkout@v6
 
@@ -75,7 +67,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-registry-
 
-      - name: Cache target/debug
+      - &cache-debug
+        name: Cache target/debug
         uses: actions/cache@v5
         with:
           path: target/debug
@@ -84,17 +77,20 @@ jobs:
             ${{ runner.os }}-cargo-target-
             ${{ runner.os }}-
 
-      - name: Build (offline-mode)
-        run: cargo build --locked
-
-      - name: Build (online-mode)
-        run: cargo build --locked --features network
+      - name: Check formatting
+        run: cargo fmt -- --check
 
       - name: Clippy (offline-mode)
         run: cargo clippy --all-targets -- -D warnings
 
       - name: Clippy (online-mode)
         run: cargo clippy --features network --all-targets -- -D warnings
+
+      - name: Build (offline-mode)
+        run: cargo build --locked
+
+      - name: Build (online-mode)
+        run: cargo build --locked --features network
 
       - name: Unit tests (offline-mode)
         run: cargo test
@@ -126,5 +122,13 @@ jobs:
       - name: Build (online-mode)
         run: cargo build --locked --release --features network
 
+  build-doc:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - *cache-registry
+      - *cache-debug
       - name: Build documentation
         run: cargo doc --all-features --no-deps

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -1,0 +1,34 @@
+name: "CodeQL (Actions)"
+
+on:
+  push:
+    branches: ["master"]
+    paths: &paths
+      - ".github/workflows/**"
+  pull_request:
+    branches: ["master"]
+    paths: *paths
+  schedule:
+    - cron: "33 4 * * 0"
+
+jobs:
+  analyze:
+    permissions:
+      security-events: write
+    runs-on: "ubuntu-latest"
+    name: Analyze
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: actions
+          build-mode: none
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:actions"

--- a/.github/workflows/codeql-rust.yml
+++ b/.github/workflows/codeql-rust.yml
@@ -1,30 +1,24 @@
-name: "CodeQL Advanced"
+name: "CodeQL (Rust)"
 
 on:
   push:
     branches: ["master"]
+    paths: &paths
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
   pull_request:
     branches: ["master"]
+    paths: *paths
   schedule:
     - cron: "33 4 * * 0"
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
-    runs-on: "ubuntu-latest"
-
     permissions:
       security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: actions
-            build-mode: none
-          - language: rust
-            build-mode: none
-
+    runs-on: "ubuntu-latest"
+    name: Analyze
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -32,11 +26,11 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
+          languages: rust
+          build-mode: none
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:${{matrix.language}}"
+          category: "/language:rust"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -20,17 +20,13 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-llvm-cov
-          key: ${{ runner.os }}-cargo-llvm-cov-0.8.5
+          key: cargo-llvm-cov-0.8.5-${{ runner.os }}
 
       - name: Cache target/llvm-cov-target
-        id: cache-llvm-cov-target
         uses: actions/cache@v5
         with:
           path: target/llvm-cov-target
-          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-llvm-cov
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-
-            ${{ runner.os }}-
+          key: cargo-target-llvm-cov-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-llvm-cov
         if: steps.cache-llvm-cov.outputs.cache-hit != 'true'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,59 @@
+name: SonarCloud
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  analyze:
+    permissions:
+      pull-requests: read # to decorate PRs with analysis results
+    runs-on: ubuntu-latest
+    name: Analyze
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # required for SonarCloud blame and PR decoration
+
+      - name: Cache cargo-llvm-cov binary
+        id: cache-llvm-cov
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/cargo-llvm-cov
+          key: ${{ runner.os }}-cargo-llvm-cov-0.8.5
+
+      - name: Cache target/llvm-cov-target
+        id: cache-llvm-cov-target
+        uses: actions/cache@v5
+        with:
+          path: target/llvm-cov-target
+          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-llvm-cov
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-
+            ${{ runner.os }}-
+
+      - name: Install cargo-llvm-cov
+        if: steps.cache-llvm-cov.outputs.cache-hit != 'true'
+        uses: taiki-e/install-action@b651345a718c8f44efa2460560b3dbf29cbd7ee1 # v2.75.26
+        with:
+          tool: cargo-llvm-cov@0.8.5
+
+      - name: Generate code coverage
+        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+
+      - name: Fix LCOV paths for SonarCloud container
+        run: sed -i "s|$(pwd)|/github/workspace|g" lcov.info
+
+      - name: Generate Clippy report
+        run: cargo clippy --workspace --all-features --message-format=json 2>/dev/null > clippy-report.json || true
+
+      - name: Analyze with SonarCloud
+        uses: SonarSource/sonarcloud-github-action@4006f663ecaf1f8093e8e4abb9227f6041f52216 # v2.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >-
+            -Dsonar.projectKey=maestro-os_blimp
+            -Dsonar.organization=maestro-os
+            -Dsonar.rust.lcov.reportPaths=lcov.info
+            -Dsonar.rust.clippy.reportPaths=clippy-report.json

--- a/builder/src/build.rs
+++ b/builder/src/build.rs
@@ -19,14 +19,16 @@
 //! Implementation of the package building procedure.
 
 use crate::desc::BuildDescriptor;
+#[cfg(feature = "network")]
+use common::repository::remote::download_packages;
 use common::{
 	anyhow::{anyhow, bail, Result},
 	flate2::{write::GzEncoder, Compression},
 	maestro_utils::{fhs, user::get_euid},
 	package::{DependencyType, Package},
 	repository::{
-		get_package_with_constraint, get_recursive_dependencies, remote::download_packages,
-		PackagesWithRepositoryMap, Repository,
+		get_package_with_constraint, get_recursive_dependencies, PackagesWithRepositoryMap,
+		Repository,
 	},
 	tar, tokio,
 	util::{create_tmp_dir, current_arch},
@@ -123,11 +125,14 @@ async fn create_sysroot(sysroot: &Path, input_path: &Path, package: &Package) ->
 	let host_env =
 		Environment::acquire(Path::new("/"), arch)?.expect("unexpected environment lock");
 	let repos = host_env.list_repositories()?;
+
+	#[cfg(feature = "network")]
 	for r in &repos {
 		if let Some(remote) = r.get_remote() {
 			remote.fetch_index(&host_env).await?;
 		}
 	}
+
 	let pkgs: PackagesWithRepositoryMap = package
 		.deps
 		.iter()
@@ -141,7 +146,10 @@ async fn create_sysroot(sysroot: &Path, input_path: &Path, package: &Package) ->
 	let deps = get_recursive_dependencies(&pkgs, &repos, DependencyType::Run, arch)?
 		.into_iter()
 		.collect();
+
+	#[cfg(feature = "network")]
 	download_packages(&deps, arch).await?;
+
 	drop(host_env);
 	let mut target_env =
 		Environment::acquire(sysroot, arch)?.expect("unexpected environment lock");

--- a/client/src/install.rs
+++ b/client/src/install.rs
@@ -19,14 +19,14 @@
 //! This module handles package installation.
 
 use crate::confirm;
+#[cfg(feature = "network")]
+use common::maestro_utils::util::ByteSize;
+#[cfg(feature = "network")]
+use common::repository::PackagesWithRepositoryVec;
 use common::{
 	anyhow::{bail, Result},
-	maestro_utils::util::ByteSize,
 	package::{DependencyType, Package},
-	repository::{
-		self, get_recursive_dependencies, PackagesWithRepositoryMap, PackagesWithRepositoryVec,
-		Repository,
-	},
+	repository::{self, get_recursive_dependencies, PackagesWithRepositoryMap, Repository},
 	Environment,
 };
 use std::collections::HashMap;
@@ -125,7 +125,7 @@ pub async fn install(names: &[String], env: &mut Environment) -> Result<()> {
 	print_download_size(&total_packages, env.arch()).await?;
 	#[cfg(not(feature = "network"))]
 	{
-		for pkg in total_packages.keys() {
+		for (pkg, _) in total_packages.iter() {
 			println!("\t- {} {} - cached", pkg.name, pkg.version);
 		}
 	}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -33,8 +33,10 @@ pub mod repository;
 pub mod util;
 pub mod version;
 
+#[cfg(feature = "network")]
+use crate::repository::remote::Remote;
 use crate::{
-	repository::{remote::Remote, PackagesWithRepositoryVec, Repository},
+	repository::{PackagesWithRepositoryVec, Repository},
 	version::Version,
 };
 use anyhow::{bail, Result};
@@ -51,9 +53,12 @@ use std::{
 const LOCK_PATH: &str = "var/lib/blimp/.lock";
 /// Directory storing information about installed packages
 const INSTALLED_DB: &str = "var/lib/blimp/installed";
+
 /// The file which contains the list of remotes
+#[cfg(feature = "network")]
 const REMOTES_LIST: &str = "var/lib/blimp/remotes-list";
 /// Directory containing remote repositories
+#[cfg(feature = "network")]
 const REMOTES: &str = "var/lib/blimp/remotes";
 
 /// The user agent for HTTP requests.
@@ -122,18 +127,23 @@ impl Environment {
 
 	/// List local & remote repositories
 	pub fn list_repositories(&self) -> Result<Vec<Repository>> {
-		let repos = self
+		#[allow(unused_mut)]
+		let mut repos = self
 			.local_repos()
 			.iter()
 			.cloned()
 			.map(Repository::local)
-			// Add remote repositories
-			.chain(
-				Remote::load_list(self)?
-					.iter()
-					.map(|r| r.load_repository(self).unwrap()),
-			) // TODO handle error
 			.collect::<Vec<_>>();
+
+		// Add remote repositories
+		// TODO handle error
+		#[cfg(feature = "network")]
+		repos.extend(
+			Remote::load_list(self)?
+				.iter()
+				.map(|r| r.load_repository(self).unwrap()),
+		);
+
 		Ok(repos)
 	}
 


### PR DESCRIPTION
- Reduce runner execution time
  - Balance execution time between build-debug & build-release: move documentation building to a dedicated job & move the format job into build-debug
  - Improve caching: add cache for llvm-cov target (sonarcloud)
  - Run CodeQL conditionally: run for rust if rust files changes, run for actions if workflows changes
- Fixes
  - **Offline-mode build**
  - All offline-mode builds were in fact online-mode ones
  - Missing --all-targets params in some build steps
- Other Refactoring
  - Dedicated SonarCloud Actions workflow
  - Rename Check workflow to Build & consistent casing for job names
  - Use more readable cache keys (variables at the end) 